### PR TITLE
fix: removed unecessary api_key variable from ChatOpenAI encapsulated…

### DIFF
--- a/service/handler_modelo.py
+++ b/service/handler_modelo.py
@@ -3,19 +3,15 @@ import openai
 from dotenv import load_dotenv
 from langsmith.wrappers import wrap_openai
 from langchain_openai import ChatOpenAI
-from pydantic import SecretStr
 
 load_dotenv()
 
 class HandlerModelo:
     def __init__(self) -> None:
-        chave_api_openai = os.environ.get('OPENAI_API_KEY')
-        self.converted_api_key = SecretStr(chave_api_openai) if chave_api_openai else None
         self.client = wrap_openai(openai.Client())
         self.model = ChatOpenAI(
             name="gpt-4o-mini", 
             temperature=0, 
-            api_key=self.converted_api_key,
         )
         
     def buscar_modelo(self) -> ChatOpenAI:


### PR DESCRIPTION
According to docs in the ChatOpenAI class, it is unecessary to set manually the api_key variable:

    .. dropdown:: Key init args — client params

        timeout: Union[float, Tuple[float, float], Any, None]
            Timeout for requests.
        max_retries: Optional[int]
            Max number of retries.
        **api_key: Optional[str]
            OpenAI API key. If not passed in will be read from env var OPENAI_API_KEY.**